### PR TITLE
Added schema validation.

### DIFF
--- a/scripts/builddes.sh
+++ b/scripts/builddes.sh
@@ -9,8 +9,9 @@
 #
 # Before running, you'll need to install some of that node.js goodness...
 # yum install npm
-# npm i -g raml2html tv4
+# npm i -g raml2html tv4 ajv 
 # export NODE_PATH=/usr/lib/node_modules
+# For ubuntu: export NODE_PATH=/usr/local/lib/node_modules
 
 # use location of this script to locate other scripts
 SCRIPTDIR="$( cd "$( dirname "$0" )" && pwd )"

--- a/scripts/validateschemas.js
+++ b/scripts/validateschemas.js
@@ -2,23 +2,51 @@
 
 var tv4 = require('tv4');
 var fs=require('fs');
+var Ajv = require('ajv');
+var ajv = Ajv();
 
 var args = process.argv.slice(2);
 
 var dir = args[0];
 
+var schemasHaveErrors = false;
+
+validateSchemas();
 
 //main
-loadSchemas();
+if (!schemasHaveErrors) {
+	loadSchemas();
 
-// to check a single schema, do this:
-// ./scripts/validateschemas.js . theSchema.json 
+	// to check a single schema, do this:
+	// ./scripts/validateschemas.js . theSchema.json 
 
-if (args.length == 1)
-	validateAllSchemaExamples();
-else
-	validateSchemaExamples(args[1]);
+	if (args.length == 1)
+		validateAllSchemaExamples();
+	else
+		validateSchemaExamples(args[1]);
+} else {
+	console.log('\nschemas have errors, please fix the errors to continue validation\n');
+}
 
+
+function validateSchemas() {
+	var schemaFiles = fs.readdirSync(dir + '/schemas')
+		.map( function(file) {
+			return dir + '/schemas/' + file;
+		});
+
+	console.log('begin validating schemas');
+	schemaFiles.forEach( function (file) {
+		console.log('  validating ' + file);
+		var schema = JSON.parse(fs.readFileSync(file));
+		ajv.validateSchema(schema);
+		if (ajv.errors) {
+			schemasHaveErrors = true;
+		       	console.log('    ERROR: ' + JSON.stringify(ajv.errors, null, 4));
+		}
+	});
+	console.log('end validating schemas');
+}
 
 function loadSchemas() {
 	//load individual schemas. tv4 does not (in any obvious way) report errors for missing schemas, so its important to load them! 
@@ -46,7 +74,7 @@ function validateExamplesForSchema(schemaFile) {
 		if (exampleFileBase.localeCompare(schemaFileName) == 0) {
 			exampleFound = true;
 			
-			console.log('    example: ' + exampleFile);
+			console.log('	 example: ' + exampleFile);
 			var exampleText = fs.readFileSync(dir + '/examples/' + exampleFile);
 			var example = JSON.parse(exampleText);
 			var res = tv4.validateMultiple(example,


### PR DESCRIPTION
Validation is done via the ajv package, since tv4 seems to have issues
with validating schemas (https://github.com/geraintluff/tv4/issues/75)
and ajv has schema validation built in.

Note that the validateschemas.js script does not validate the examples if
the schemas have errors.
